### PR TITLE
use github env files bc of deprecation of set-env 

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -229,7 +229,7 @@ export_env() {
 	local value="$2"
 
 	if [ -n "$GITHUB_ACTION" ] ; then
-		echo "::set-env name=${variable}::${value}"
+		echo "$variable=$value" >> ${GITHUB_ENV}
 	else
 		echo "$variable=$value"
 	fi


### PR DESCRIPTION
[Apparently set-env is deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)

It failed my chart lint here: https://github.com/datawire/ambassador-chart/pull/144/checks?check_run_id=1420690141

This change seems to have fixed it: https://github.com/datawire/ambassador-chart/pull/145/checks?check_run_id=1425310066